### PR TITLE
Fix navbar loader path resolution

### DIFF
--- a/js/navbar-loader.js
+++ b/js/navbar-loader.js
@@ -1,5 +1,7 @@
+const navUrl = new URL('navbar.html', document.currentScript.src);
+
 document.addEventListener("DOMContentLoaded", () => {
-  fetch('../js/navbar.html')
+  fetch(navUrl)
     .then(response => {
       if (!response.ok) throw new Error('Navbar load error');
       return response.text();


### PR DESCRIPTION
## Summary
- Ensure `navbar-loader.js` derives `navbar.html` path relative to the script file so navbar loads from any directory

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a65784b1d48328b59184d2c6a5d40c