### PR TITLE
Disable 'Where I've Worked' tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
             <a class="nav-link disabled" href="pages/Portfolio.html">Portfolio&nbsp;</a>
           </li>
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="JobDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <a class="nav-link dropdown-toggle disabled" href="#" id="JobDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="-1" aria-disabled="true">
             Where I've Worked
             </a>
             <div class="dropdown-menu" aria-labelledby="JobDropdown">

--- a/js/navbar.html
+++ b/js/navbar.html
@@ -13,14 +13,14 @@
 	  <li class="nav-item">
 		<a class="nav-link disabled" href="../pages/Portfolio.html">Portfolio&nbsp;</a>
 	  </li>
-	  <li class="nav-item dropdown">
-		<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-		Where I've Worked
-		</a>
-		<div class="dropdown-menu" aria-labelledby="navbarDropdown">
-		  <a class="dropdown-item disabled" href="#">First Job</a>
-		</div>
-	  </li>
+          <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle disabled" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="-1" aria-disabled="true">
+                Where I've Worked
+                </a>
+                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                  <a class="dropdown-item disabled" href="#">First Job</a>
+                </div>
+          </li>
 		<li class="nav-item">
 		<a class="nav-link" href="#">University&nbsp;</a>
 	  </li>
@@ -34,5 +34,5 @@
 		<a href="https://www.instagram.com/_jakeastles/" target="_blank"><img src="../images/Instagram Logo.png" width="35" height="35" alt="Instagram"/></a>
 		<a href="https://trello.com/u/davr547/activity" target="_blank"><img src="../images/Trello Logo.png" width="35" height="35" alt="Trello"/></a>
 	</div>
-	</div>
+        </div>
 </nav>


### PR DESCRIPTION
Fixed the navbar so only the relevant tabs are accessible. The tabindex property was used to stop screenreaders and the tab feature from accessing/selecting the disabled button.