### PR TITLE
Use local Bootstrap 5.0.2 with minimal portfolio layout changes

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -11,6 +11,34 @@ html {
   text-stroke: 1px #9fcdff;
 }
 
+/* Bootstrap 4 utilities/components retained by the existing page markup. */
+.jumbotron {
+  padding: 2rem 1rem;
+  margin-bottom: 2rem;
+  background-color: #e9ecef;
+  border-radius: 0.3rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.text-left {
+  text-align: left !important;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .donation-box {
   background-color: rgba(248, 249, 250, 0.95);
   border: 2px solid #b6d8ff;
@@ -98,6 +126,13 @@ html {
   text-align: left;
 }
 
+.portfolio-grid {
+  width: 100%;
+  max-width: 2400px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .portfolio-feature-card {
   border: 0;
   border-radius: 1.25rem;
@@ -107,8 +142,11 @@ html {
 }
 
 .portfolio-feature-card .card-img-top {
-  height: 18rem;
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
   object-fit: cover;
+  object-position: center;
 }
 
 .portfolio-feature-card .card-body {
@@ -277,6 +315,24 @@ html {
 .year-three-card .card-title a,
 .year-three-card .card-text {
   color: #ffffff;
+}
+
+@media (min-width: 576px) {
+  .jumbotron {
+    padding: 4rem 2rem;
+  }
+}
+
+@media (min-width: 1920px) {
+  .portfolio-feature-card .card-img-top {
+    aspect-ratio: 3 / 2;
+  }
+}
+
+@media (min-width: 2560px) {
+  .portfolio-feature-card .card-img-top {
+    aspect-ratio: 4 / 3;
+  }
 }
 
 @media (max-width: 767.98px) {

--- a/home/index.html
+++ b/home/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <title>Jake Astles | Home</title>
     <!-- Bootstrap -->
-	<link href="/css/bootstrap-4.4.1.min.css" rel="stylesheet">
+	<link href="/css/bootstrap-5.0.2.min.css" rel="stylesheet">
 	<link href="/css/custom.css" rel="stylesheet">
   </head>
   <body>
@@ -102,11 +102,9 @@
         </div>
       </div>
     </footer>
-    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="/js/jquery-3.4.1.min.js"></script>
-    <!-- Include all compiled plugins (below), or include individual files as needed -->
-	<script src="/js/popper.min.js"></script>
-    <script src="/js/bootstrap-4.4.1.js"></script>
+    <!-- Bootstrap 5 does not require jQuery. Popper 2 is required by dropdowns. -->
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="/js/bootstrap-5.0.2.min.js"></script>
     <script src="/js/contact-form.js"></script>
     <script src="/js/donation-box-loader.js"></script>
     <script src="/js/contact-loader.js"></script>

--- a/home/thanks/index.html
+++ b/home/thanks/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Thank you page for Jake Astles contact form.">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <title>Jake Astles | Thank You</title>
-    <link href="/css/bootstrap-4.4.1.min.css" rel="stylesheet">
+    <link href="/css/bootstrap-5.0.2.min.css" rel="stylesheet">
     <link href="/css/custom.css" rel="stylesheet">
   </head>
   <body>
@@ -25,14 +25,12 @@
       </div>
     </section>
 
-    <div class="modal fade" id="thanksModal" tabindex="-1" role="dialog" aria-labelledby="thanksModalLabel" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal fade" id="thanksModal" tabindex="-1" aria-labelledby="thanksModalLabel" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="thanksModalLabel">Thank You!</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
             <p>
@@ -41,7 +39,7 @@
             </p>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
           </div>
         </div>
       </div>
@@ -61,15 +59,16 @@
       </div>
     </footer>
 
-    <script src="/js/jquery-3.4.1.min.js"></script>
-    <script src="/js/popper.min.js"></script>
-    <script src="/js/bootstrap-4.4.1.js"></script>
+    <!-- Bootstrap 5 does not require jQuery. Popper 2 is required by dropdowns. -->
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="/js/bootstrap-5.0.2.min.js"></script>
     <script src="/js/contact-form.js"></script>
     <script src="/js/contact-loader.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', function () {
-        if (typeof $ === 'function' && $('#thanksModal').length) {
-          $('#thanksModal').modal('show');
+        const modalElement = document.getElementById('thanksModal');
+        if (modalElement) {
+          new bootstrap.Modal(modalElement).show();
         }
       });
     </script>

--- a/js/navbar.html
+++ b/js/navbar.html
@@ -2,11 +2,11 @@
   <a class="navbar-brand" href="/home/">
 	  Jake Astles&nbsp;<br>
   </a>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
   <span class="navbar-toggler-icon"></span>
   </button>
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
-	<ul class="navbar-nav mr-auto">
+	<ul class="navbar-nav me-auto">
 	  <li class="nav-item">
 		<a class="nav-link" href="/home/">Home</a>
 	  </li>
@@ -14,7 +14,7 @@
 		<a class="nav-link" href="/pages/portfolio/">Portfolio&nbsp;</a>
 	  </li>
           <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle disabled" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="-1" aria-disabled="true">
+                <a class="nav-link dropdown-toggle disabled" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" tabindex="-1" aria-disabled="true">
                 Where I've Worked
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">

--- a/pages/play/index.html
+++ b/pages/play/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Jake Astles - Play page for browser-playable projects.">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <title>Jake Astles | Play</title><!--Last word must be navbar link name for link to be highlighted-->
-    <link href="/css/bootstrap-4.4.1.min.css" rel="stylesheet">
+    <link href="/css/bootstrap-5.0.2.min.css" rel="stylesheet">
     <link href="/css/custom.css" rel="stylesheet">
   </head>
   <body>
@@ -76,12 +76,11 @@
       </div>
     </footer>
 
-    <script src="/js/jquery-3.4.1.min.js"></script>
-    <script src="/js/popper.min.js"></script>
-    <script src="/js/bootstrap-4.4.1.js"></script>
+    <!-- Bootstrap 5 does not require jQuery. Popper 2 is required by dropdowns. -->
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="/js/bootstrap-5.0.2.min.js"></script>
     <script src="/js/contact-form.js"></script>
     <script src="/js/donation-box-loader.js"></script>
     <script src="/js/contact-loader.js"></script>
   </body>
 </html>
-

--- a/pages/portfolio/index.html
+++ b/pages/portfolio/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <title>Jake Astles | Portfolio</title><!--Last word must be navbar link name for link to be highlighted-->
     <!-- Bootstrap -->
-    <link href="/css/bootstrap-4.4.1.min.css" rel="stylesheet">
+    <link href="/css/bootstrap-5.0.2.min.css" rel="stylesheet">
 	<link href="/css/custom.css" rel="stylesheet">
   </head>
   <body>
@@ -32,7 +32,7 @@
 		<h1 id="Personal-Section">Personal</h1>
 	</div>
     <section>
-		  <div class="row g-4">
+		  <div class="row g-4 portfolio-grid">
 			  <div class="col-12 col-lg-6">
 				<div class="card h-100 portfolio-feature-card portfolio-feature-card--ggj">
 				  <a href="https://github.com/Lopsitey/GGJ-2026" target="_blank"><img src="/media/Survival-By-Spear.png" class="card-img-top" alt="Preview image for GGJ 2026"></a>
@@ -99,11 +99,9 @@
         </div>
       </div>
     </footer>
-    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="/js/jquery-3.4.1.min.js"></script>
-    <!-- Include all compiled plugins (below), or include individual files as needed -->
-    <script src="/js/popper.min.js"></script>
-    <script src="/js/bootstrap-4.4.1.js"></script>
+    <!-- Bootstrap 5 does not require jQuery. Popper 2 is required by dropdowns. -->
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="/js/bootstrap-5.0.2.min.js"></script>
     <script src="/js/contact-form.js"></script>
     <script src="/js/donation-box-loader.js"></script>
     <script src="/js/contact-loader.js"></script>

--- a/pages/university/index.html
+++ b/pages/university/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <title>Jake Astles | University</title><!--Last word must be navbar link name for link to be highlighted-->
     <!-- Bootstrap -->
-    <link href="/css/bootstrap-4.4.1.min.css" rel="stylesheet">
+    <link href="/css/bootstrap-5.0.2.min.css" rel="stylesheet">
     <link href="/css/custom.css" rel="stylesheet">
   </head>
   <body class="university-page">
@@ -308,11 +308,9 @@
         </div>
       </div>
     </footer>
-    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="/js/jquery-3.4.1.min.js"></script>
-    <!-- Include all compiled plugins (below), or include individual files as needed -->
-    <script src="/js/popper.min.js"></script>
-    <script src="/js/bootstrap-4.4.1.js"></script>
+    <!-- Bootstrap 5 does not require jQuery. Popper 2 is required by dropdowns. -->
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js"></script>
+    <script src="/js/bootstrap-5.0.2.min.js"></script>
     <script src="/js/contact-form.js"></script>
     <script src="/js/donation-box-loader.js"></script>
     <script src="/js/contact-loader.js"></script>


### PR DESCRIPTION
## Summary
- uses the newly added local Bootstrap 5.0.2 CSS and JavaScript on all five Bootstrap-powered pages
- removes page-level jQuery usage because the site's own scripts are vanilla JavaScript
- replaces the old Popper 1 reference with Popper 2.9.2, which is compatible with Bootstrap 5
- updates only the required shared navbar attributes/classes for Bootstrap 5
- migrates the thank-you modal from the jQuery API to `bootstrap.Modal`
- preserves the existing jumbotron, contact form, card, university, and page markup by adding small compatibility rules to `custom.css`

## Portfolio-specific changes
- keeps the existing `.portfolio-feature-card` styling
- adds only `portfolio-grid` to the existing row
- constrains that row to 2400px on very wide screens
- replaces the fixed `18rem` feature-image height with responsive ratios:
  - 16:9 normally
  - 3:2 from 1920px
  - 4:3 from 2560px
- keeps the newly pushed `/media/Ballatro.png`

## Scope
This is intentionally a minimal diff from the latest `main`: seven files, with roughly 5–12 changed lines per HTML page. The previous broad PR was closed and superseded by this one.